### PR TITLE
Possible fix for loading breweries based on geolocation

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -37,12 +37,6 @@ function getCoords(){
             body: JSON.stringify(data)
                 }
 
-            
-            const response = await fetch('/api', options)
-           const json = await response.json()
-           console.log(json)
-           coordsArray.push(json)
-           console.log(coordsArray)
 
     fetch(coordsURL)
             .then(res => res.json())


### PR DESCRIPTION
Why: When fetch() tries to make an http request for "/api" it fails, because "/api" is not a valid domain name (domain names are like www.google.com). When fetch() fails it throws an exception that causes the execution of getCords() to end before performing the fetch() for breweries.

*---

How: When there are no exceptions, getCords() seems to work as intended.

*---